### PR TITLE
[Feature]: Automate release creation from changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        # Fetch all history for all branches and tags
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Extract Release Notes from CHANGELOG.md
+        id: extract_notes
+        run: |
+          # The github.ref_name context variable holds the tag name (e.g., "v1.0.2")
+          VERSION_TAG="${{ github.ref_name }}"
+          # Remove the 'v' prefix from the tag to get the pure version number
+          VERSION_NUMBER="${VERSION_TAG#v}"
+          echo "Extracting notes for version: $VERSION_NUMBER"
+          python scripts/extract_release_notes.py "$VERSION_NUMBER" CHANGELOG.md RELEASE_NOTES.md
+          echo "---- Contents of generated RELEASE_NOTES.md ----"
+          cat RELEASE_NOTES.md
+          echo "---- End of RELEASE_NOTES.md ----"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: RELEASE_NOTES.md
+          name: TimeTrack ${{ github.ref_name }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Your new fix here.
 
 
+## [1.0.3] - 2025-07-31
+
+### Added
+- Implemented a GitHub Actions workflow to automate the creation of releases.
+- Added a Python script (`scripts/extract_release_notes.py`) to parse release notes for a specific version from `CHANGELOG.md`.
+
+### Changed
+- The new release workflow automatically populates the body of a GitHub Release using the content from the changelog when a new version tag (e.g., `v1.0.3`) is pushed.
+
+
 ## [1.0.2] - 2025-07-31
 
 ### Fixed
@@ -41,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [Unreleased]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.1...HEAD
+[1.0.3]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/PPeitsch/TimeTrack/releases/tag/v1.0.0

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,89 @@
+"""Extracts release notes for a specific version from a CHANGELOG.md file."""
+
+import re
+import sys
+from typing import Optional
+
+
+def get_version_section(content: str, version_number: str) -> Optional[str]:
+    """
+    Find and return the content for a specific version section in the changelog.
+
+    Args:
+        content: The full content of the changelog file.
+        version_number: The version string to look for (e.g., "1.0.2").
+
+    Returns:
+        The content of the version section if found, otherwise None.
+    """
+    # Regex to find the start of the version section: "## [version]"
+    # It captures everything until the next "## [" (start of another version)
+    # or the end of the string (\Z).
+    escaped_version_number = re.escape(version_number)
+    pattern = re.compile(
+        r"##\s*\[" + escaped_version_number + r"\][^\n]*\n(.*?)(?=\n##\s*\[|\Z)",
+        re.DOTALL | re.MULTILINE,
+    )
+    match = pattern.search(content)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def main(version_number: str, changelog_filepath: str, output_filepath: str) -> None:
+    """
+    Read a changelog, extract notes for a version, and write them to an output file.
+
+    Args:
+        version_number: The version to extract notes for.
+        changelog_filepath: Path to the CHANGELOG.md file.
+        output_filepath: Path where the extracted notes will be written.
+    """
+    try:
+        with open(changelog_filepath, "r", encoding="utf-8") as f_changelog:
+            changelog_content = f_changelog.read()
+    except FileNotFoundError:
+        print(f"Error: Changelog file not found at '{changelog_filepath}'.")
+        sys.exit(1)
+
+    extracted_notes = get_version_section(changelog_content, version_number)
+
+    if extracted_notes:
+        try:
+            with open(output_filepath, "w", encoding="utf-8") as f_output:
+                f_output.write(extracted_notes)
+            print(f"Successfully extracted release notes for version {version_number}.")
+        except IOError as e:
+            print(f"Error writing extracted notes to '{output_filepath}': {e}")
+            sys.exit(1)
+    else:
+        print(f"Warning: Version section for '{version_number}' not found.")
+        try:
+            with open(output_filepath, "w", encoding="utf-8") as f_output:
+                f_output.write(
+                    f"Release notes for version {version_number} not found in {changelog_filepath}."
+                )
+        except IOError as e:
+            print(f"Error writing placeholder message to '{output_filepath}': {e}")
+        # We exit with an error because a release should not be created
+        # without proper release notes.
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print(
+            "Usage: python extract_release_notes.py <version_without_v> "
+            "<changelog_path> <output_path>"
+        )
+        print(
+            "Example: python scripts/extract_release_notes.py 1.0.2 "
+            "CHANGELOG.md RELEASE_NOTES.md"
+        )
+        sys.exit(1)
+
+    script_version = sys.argv[1]
+    script_changelog = sys.argv[2]
+    script_output = sys.argv[3]
+
+    main(script_version, script_changelog, script_output)


### PR DESCRIPTION
## Description

This pull request introduces a new automated workflow to streamline the project's release process. The goal is to eliminate manual steps and ensure that GitHub releases are always consistent with the `CHANGELOG.md`.

The implementation includes two key components:

1.  **Release Note Extraction Script:** A new Python script, `scripts/extract_release_notes.py`, has been added. This script is responsible for parsing the `CHANGELOG.md` file, finding the section corresponding to a given version tag, and extracting its content.

2.  **GitHub Actions Workflow:** A new workflow file, `.github/workflows/release.yaml`, has been created. This workflow is triggered whenever a new tag matching the pattern `v*` is pushed to the repository. It performs the following actions:
    *   Checks out the repository code.
    *   Runs the extraction script to get the relevant release notes.
    *   Uses the extracted notes to automatically create a new, published GitHub Release, titling it with the version tag.

This automation makes the release process faster, more reliable, and less prone to human error.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Configuration change

## Testing

- The `extract_release_notes.py` script was tested locally to confirm it correctly extracts content for existing versions from `CHANGELOG.md`.
- The workflow was tested in a fork by pushing a new tag. Confirmed that:
    - The workflow triggers successfully.
    - The Python script executes without errors.
    - A new GitHub Release is created with the correct title and body content from the changelog.

## Checklist

- [x] I have followed the project's code style (Black, isort, PEP 8)
- [x] My code generates no new warnings
- [ ] I have added tests for new functionality (N/A - Workflow functionality tested via execution)
- [x] All tests pass locally
- [x] I have updated the documentation where necessary (Changelog updated)
- [x] I have run pre-commit hooks before submitting

⚡ *Have you read the [Contributing Guidelines](CONTRIBUTING.md)?* Yes

Fixes #12 