### PR TITLE
[Feature]: Add GitHub issue template for documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -1,0 +1,50 @@
+name: Documentation Report
+description: Report an issue or suggest an improvement for the documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve our documentation! Please provide the details of the issue below.
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Type of Issue
+      description: What kind of documentation issue is this?
+      options:
+        - Incorrect information
+        - Outdated content
+        - Unclear explanation
+        - Typo or grammatical error
+        - Suggestion for new documentation
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location of the Issue
+      description: "Please provide the file path or URL of the documentation page."
+      placeholder: "e.g., README.md or /app/routes/time_summary.py"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of the Issue
+      description: "A clear and concise description of what the problem is."
+      placeholder: "In the Quick Start section, the command for activating the virtual environment on Windows is incorrect."
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Change
+      description: "How do you suggest we fix this? Please provide the corrected text if possible."
+      placeholder: "Change `venv/script/activate` to `venv\\Scripts\\activate`"
+    validations:
+      required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Your new fix here.
 
 
+## [1.0.5] - 2025-07-31
+
+### Added
+- Created a dedicated GitHub issue template (`docs.yaml`) for documentation-related reports to standardize submissions and improve clarity.
+
+
 ## [1.0.4] - 2025-07-31
 
 ### Fixed
@@ -57,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [Unreleased]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.1...HEAD
+[1.0.5]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PPeitsch/TimeTrack/compare/v1.0.1...v1.0.2


### PR DESCRIPTION
## Description

This pull request adds a dedicated GitHub issue template for documentation reports, as outlined in the feature request. The new template, located at `.github/ISSUE_TEMPLATE/docs.yaml`, provides a structured form for users to submit documentation issues, including fields for the type of issue, its location, and the suggested changes.

This will streamline the process of reporting and addressing documentation improvements, making it easier for both contributors and maintainers.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [x] Documentation update (Project metadata)
- [ ] Configuration change

## Testing

- Manually verified that the new "Documentation Report" template appears as an option when creating a new issue on GitHub.
- Confirmed that selecting the template presents the user with the correct form fields as defined in `docs.yaml`.

## Checklist

- [x] I have followed the project's code style (Black, isort, PEP 8)
- [x] My code generates no new warnings
- [ ] I have added tests for new functionality (N/A)
- [x] All tests pass locally
- [x] I have updated the documentation where necessary (Changelog updated)
- [x] I have run pre-commit hooks before submitting

⚡ *Have you read the [Contributing Guidelines](CONTRIBUTING.md)?* Yes

Fixes #5 