### PR TITLE
fix(ci): Remove project name prefix from automatic release title

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: RELEASE_NOTES.md
-          name: TimeTrack ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Your new fix here.
 
 
+## [1.0.8] - 2025-08-06
+
+### Fixed
+- The automatic release workflow no longer adds a redundant "TimeTrack" prefix to the GitHub release title, which now consists only of the version tag.
+
+
 ## [1.0.7] - 2025-08-06
 
 ### Added


### PR DESCRIPTION
## Description

This pull request addresses a minor formatting issue in the automated release process. The `release.yaml` workflow was previously configured to prepend "TimeTrack" to the release title, resulting in redundant titles like "TimeTrack v1.0.8".

This has been corrected by removing the hardcoded prefix. The release title will now be created using only the version tag (e.g., `v1.0.8`), which is cleaner and more standard.

## Type of Change

- [x] Bug fix
- [x] Configuration change (CI/CD)

## Testing

- The change is confined to a single line in the `release.yaml` workflow file.
- Manually verified the syntax of the YAML file.
- The next release created with this workflow will serve as the final confirmation of the fix.

## Checklist

- [x] I have followed the project's code style (Black, isort, PEP 8)
- [x] My code generates no new warnings
- [ ] I have added tests for new functionality (N/A - Workflow configuration change)
- [x] All tests pass locally
- [x] I have updated the documentation where necessary (Changelog updated)
- [x] I have run pre-commit hooks before submitting

<!---
⚡ *Have you read the [Contributing Guidelines](CONTRIBUTING.md)?* 
--->

Fixes #18